### PR TITLE
Revert "chore(deps): bump io.opentelemetry:opentelemetry-exporter-otlp from 1.32.0 to 1.33.0 in /src/orderbook"

### DIFF
--- a/src/orderbook/build.gradle.kts
+++ b/src/orderbook/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 
     // Tracing
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.33.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.32.0")
 
     implementation("org.springframework.cloud:spring-cloud-starter-consul-discovery")
 


### PR DESCRIPTION
Reverts exchange-all/exchange-api#84