### PR TITLE
Revert "chore(deps): bump io.opentelemetry:opentelemetry-exporter-otlp from 1.32.0 to 1.33.0 in /src/exchange"

### DIFF
--- a/src/exchange/build.gradle.kts
+++ b/src/exchange/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
 
     // tracing
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.33.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.32.0")
 
 
     // consul


### PR DESCRIPTION
Reverts exchange-all/exchange-api#85