### PR TITLE
Revert "chore(deps): bump io.opentelemetry:opentelemetry-exporter-otlp from 1.32.0 to 1.33.0 in /src/gateway"

### DIFF
--- a/src/gateway/build.gradle.kts
+++ b/src/gateway/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     // Tracing
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.33.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.32.0")
 
 //    runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp-common:1.33.0")
 


### PR DESCRIPTION
Reverts exchange-all/exchange-api#86