### PR TITLE
Revert "chore(deps): bump io.opentelemetry:opentelemetry-exporter-otlp from 1.32.0 to 1.33.0 in /src/auth-service"

### DIFF
--- a/src/auth-service/build.gradle.kts
+++ b/src/auth-service/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 
     // Tracing
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.33.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.32.0")
 
 }
 


### PR DESCRIPTION
Reverts exchange-all/exchange-api#87